### PR TITLE
Include camera and lights in objects popover

### DIFF
--- a/ControlsPanel.bas
+++ b/ControlsPanel.bas
@@ -256,26 +256,80 @@ public Sub AddModelBarToPopover(popover As PopoverPanelView, event As String) As
 End Sub
 
 public Sub refreshObjectPopover
-	popoverObjectsList.containerPanel.Panel.RemoveAllViews
-	For Each obj As cModel In Main.Scene.Models
-		Dim model As ModelBar = AddModelBarToPopover(popoverObjectsList, "objectsList")
-		model.Title = obj.mesh.Name
-		model.Tag = obj
-	Next
+        Dim container As Panel = popoverObjectsList.containerPanel.Panel
+        container.RemoveAllViews
+        container.Height = 0
+
+        Dim cameraBar As ModelBar = AddModelBarToPopover(popoverObjectsList, "objectsList")
+        cameraBar.Title = "Camera"
+        cameraBar.Tag = CreateMap("type": "camera", "ref": Main.Scene.Camera)
+        cameraBar.SetToggleEnabled(False)
+
+        Dim lightIndex As Int
+        For lightIndex = 0 To Main.Scene.Lights.Size - 1
+                Dim light As cLight = Main.Scene.Lights.Get(lightIndex)
+                Dim lightBar As ModelBar = AddModelBarToPopover(popoverObjectsList, "objectsList")
+                Dim lightName As String = light.Name
+                If lightName.Length = 0 Then lightName = $"Light ${lightIndex + 1}"$
+                lightBar.Title = lightName
+                lightBar.Tag = CreateMap("type": "light", "ref": light)
+                lightBar.SetShownWithoutEvent(light.Enabled)
+        Next
+
+        For Each obj As cModel In Main.Scene.Models
+                Dim model As ModelBar = AddModelBarToPopover(popoverObjectsList, "objectsList")
+                model.Title = obj.mesh.Name
+                model.Tag = CreateMap("type": "model", "ref": obj)
+                model.SetShownWithoutEvent(obj.Visible)
+        Next
 End Sub
 
 public Sub objectsList_VisibilityChanged(visible As Boolean)
-	Dim modelB As ModelBar = Sender
-	modelB.Tag.As(cModel).Visible = visible
-	CallSub(Main, "resetTimer")
+        Dim modelB As ModelBar = Sender
+        Dim tagData As Object = modelB.Tag
+
+        If tagData Is Map Then
+                Dim data As Map = tagData
+                Dim entryType As String = data.Get("type")
+                Select entryType
+                        Case "model"
+                                Dim mdl As cModel = data.Get("ref")
+                                mdl.Visible = visible
+                        Case "light"
+                                Dim light As cLight = data.Get("ref")
+                                light.Enabled = visible
+                        Case "camera"
+                                Return
+                End Select
+        Else If tagData Is cModel Then
+                tagData.As(cModel).Visible = visible
+        End If
+
+        CallSub(Main, "resetTimer")
 End Sub
 
 
 
 public Sub objectsList_SettingsClick
-	Dim modelB As ModelBar = Sender
-	ApplyObjectDataToPopover(modelB.Tag)
-	popoverObjectSettings.ShowPanel
+        Dim modelB As ModelBar = Sender
+        Dim tagData As Object = modelB.Tag
+
+        If tagData Is Map Then
+                Dim data As Map = tagData
+                Dim entryType As String = data.Get("type")
+                Select entryType
+                        Case "model"
+                                Dim mdl As cModel = data.Get("ref")
+                                ApplyObjectDataToPopover(mdl)
+                                popoverObjectSettings.ShowPanel
+                        Case "camera"
+                                popoverCamSettings.ShowPanel
+                End Select
+                Return
+        Else If tagData Is cModel Then
+                ApplyObjectDataToPopover(tagData)
+                popoverObjectSettings.ShowPanel
+        End If
 End Sub
 
 public Sub build_PopoverRenderSettings

--- a/ModelBar.bas
+++ b/ModelBar.bas
@@ -29,8 +29,9 @@ Sub Class_Globals
 
 	' State
 	Private mTitle As String
-	Private mShown As Boolean = True
-	Public Tag As Object ' optional: store your scene object id/ref here
+        Private mShown As Boolean = True
+        Public Tag As Object ' optional: store your scene object id/ref here
+        Private ToggleEnabled As Boolean = True
 
 	' Optional bitmaps for nicer icons
 	Private BmpSettings As Bitmap
@@ -111,9 +112,27 @@ Public Sub SetIcons(Settings As Bitmap, EyeOpen As Bitmap, EyeClosed As Bitmap)
 End Sub
 
 Public Sub SetShown(shown As Boolean)
-	mShown = shown
-	UpdateEyeIcon
-	RaiseVisibilityChanged
+        mShown = shown
+        UpdateEyeIcon
+        RaiseVisibilityChanged
+End Sub
+
+Public Sub SetShownWithoutEvent(shown As Boolean)
+        If mShown = shown Then Return
+        mShown = shown
+        UpdateEyeIcon
+End Sub
+
+Public Sub SetToggleEnabled(enabled As Boolean)
+        ToggleEnabled = enabled
+        BtnEye.Enabled = enabled
+        FallbackEye.Enabled = enabled
+        BtnEye.Visible = enabled
+        FallbackEye.Visible = enabled
+        If enabled = False Then
+                SetShownWithoutEvent(True)
+        End If
+        Relayout
 End Sub
 
 Public Sub IsShown As Boolean
@@ -151,10 +170,15 @@ Private Sub Relayout
 	' Right to left: [ .. Label .. ][ Settings ][ Gap ][ Eye ]
 	Dim rightX As Int = w - Pad
 
-	' Eye
-	BtnEye.SetLayoutAnimated(0, rightX - IconSize, (h - IconSize) / 2, IconSize, IconSize)
-	FallbackEye.SetLayoutAnimated(0, BtnEye.Left, BtnEye.Top, IconSize, IconSize)
-	rightX = BtnEye.Left - Gap
+        ' Eye
+        If ToggleEnabled Then
+                BtnEye.SetLayoutAnimated(0, rightX - IconSize, (h - IconSize) / 2, IconSize, IconSize)
+                FallbackEye.SetLayoutAnimated(0, BtnEye.Left, BtnEye.Top, IconSize, IconSize)
+                rightX = BtnEye.Left - Gap
+        Else
+                BtnEye.SetLayoutAnimated(0, rightX, (h - IconSize) / 2, 0, IconSize)
+                FallbackEye.SetLayoutAnimated(0, rightX, (h - IconSize) / 2, 0, IconSize)
+        End If
 
 	' Settings
 	BtnSettings.SetLayoutAnimated(0, rightX - IconSize, (h - IconSize) / 2, IconSize, IconSize)
@@ -213,9 +237,10 @@ End Sub
 ' Interaction -----
 
 Private Sub btnEye_Click
-	mShown = Not(mShown)
-	UpdateEyeIcon
-	RaiseVisibilityChanged
+        If ToggleEnabled = False Then Return
+        mShown = Not(mShown)
+        UpdateEyeIcon
+        RaiseVisibilityChanged
 End Sub
 
 Private Sub btnSettings_Click

--- a/cLight.bas
+++ b/cLight.bas
@@ -11,12 +11,13 @@ Sub Class_Globals
 	Public Const KIND_SPOT As Int = 2
 	Public Const KIND_RECT As Int = 3     ' rectangular area (square is just equal U/V lengths)
 
-	Public Name As String = "Light"
-	Public Kind As Int = KIND_DIRECTIONAL
-	Public Direction As Vec3   ' for directional light; points FROM light to scene
-	Public Color As Int = Colors.White
-	Public Intensity As Double = 1.0
-	Public Position As Vec3      ' position for point/spot/rect
+        Public Name As String = "Light"
+        Public Kind As Int = KIND_DIRECTIONAL
+        Public Direction As Vec3   ' for directional light; points FROM light to scene
+        Public Color As Int = Colors.White
+        Public Intensity As Double = 1.0
+        Public Position As Vec3      ' position for point/spot/rect
+        Public Enabled As Boolean = True
 	
 	Public CosInner As Double = Cos(15 * cPI / 180)
 	Public CosOuter As Double = Cos(20 * cPI / 180)
@@ -27,10 +28,11 @@ Sub Class_Globals
 End Sub
 
 Public Sub Initialize(dir As Vec3)
-	Direction = Math3D.V3(0, -1, 0)
-	Position = Math3D.V3(0, 0, 0)
-	U = Math3D.V3(0, 0, 0)
-	V = Math3D.V3(0, 0, 0)
+        Direction = Math3D.V3(0, -1, 0)
+        Position = Math3D.V3(0, 0, 0)
+        U = Math3D.V3(0, 0, 0)
+        V = Math3D.V3(0, 0, 0)
+        Enabled = True
 End Sub
 
 

--- a/cRenderer.bas
+++ b/cRenderer.bas
@@ -149,14 +149,16 @@ Public Sub RenderRaster(cvs As Canvas, dstW As Int, dstH As Int, scene As cScene
 		Next
 	End If
 
-	' choose light
-	Dim lightDir As Vec3
-	If scene.Lights.Size > 0 Then
-		Dim L As cLight = scene.Lights.Get(0)
-		lightDir = L.Direction
-	Else
-		lightDir = Math3D.V3(-1,-1,-1)
-	End If
+        ' choose light
+        Dim lightDir As Vec3 = Math3D.V3(-1, -1, -1)
+        Dim li As Int
+        For li = 0 To scene.Lights.Size - 1
+                Dim L As cLight = scene.Lights.Get(li)
+                If L.Enabled Then
+                        lightDir = L.Direction
+                        Exit
+                End If
+        Next
 	Dim Lm As Vec3 = Math3D.Normalize(Math3D.Mul(lightDir, -1))   ' surface->light
 
 	
@@ -332,13 +334,16 @@ Public Sub RenderRaytrace(scene As cScene, Width As Int, Height As Int) As Resum
 	RT_Aspect = RT_W / Max(1, RT_H)
 	RT_TanHalf = Tan(scene.Camera.FOV_Deg * cPI / 180 / 2)
 	
-	' ---- light ----
-	If scene.Lights.Size > 0 Then
-		Dim L As cLight = scene.Lights.Get(0)
-		RT_LightDir = L.Direction
-	Else
-		RT_LightDir = Math3D.V3(-1, -2, -1)
-	End If
+        ' ---- light ----
+        RT_LightDir = Math3D.V3(-1, -2, -1)
+        Dim li As Int
+        For li = 0 To scene.Lights.Size - 1
+                Dim L As cLight = scene.Lights.Get(li)
+                If L.Enabled Then
+                        RT_LightDir = L.Direction
+                        Exit
+                End If
+        Next
 
 	' ---- output buffer ----
 	Pixels = Math3D.CreateIntArray(RT_W * RT_H)
@@ -1105,13 +1110,17 @@ Public Sub RenderPathTrace(scene As cScene, dstW As Int, dstH As Int, spp As Int
 	BuildBVH_FromRTFrame
 
 	' Light (directional) from scene
-	Dim haveLight As Boolean = False
-	Dim Ldir As Vec3 = Math3D.V3(-1, -1, -1)
-	If scene.Lights.Size > 0 Then
-		Dim L As cLight = scene.Lights.Get(0)
-		Ldir = L.Direction
-		haveLight = True
-	End If
+        Dim haveLight As Boolean = False
+        Dim Ldir As Vec3 = Math3D.V3(-1, -1, -1)
+        Dim li As Int
+        For li = 0 To scene.Lights.Size - 1
+                Dim L As cLight = scene.Lights.Get(li)
+                If L.Enabled Then
+                        Ldir = L.Direction
+                        haveLight = True
+                        Exit
+                End If
+        Next
 	Dim LightToSurf As Vec3 = Math3D.Normalize(Math3D.Mul(Ldir, -1))  ' points from surface toward light
 
 	EnsurePathBuffers(dstW, dstH)
@@ -1338,10 +1347,11 @@ Private Sub RT_DirectLight(p As Vec3, n As Vec3, base As Vec3, faceIndex As Int)
 	If RT_Scene = Null Then
 		Return sum
 	End If
-	Dim i As Int
-	For i = 0 To RT_Scene.Lights.Size - 1
-		Dim L As cLight = RT_Scene.Lights.Get(i)
-		Dim E As Vec3 = LightRGB(L)
+        Dim i As Int
+        For i = 0 To RT_Scene.Lights.Size - 1
+                Dim L As cLight = RT_Scene.Lights.Get(i)
+                If L.Enabled = False Then Continue
+                Dim E As Vec3 = LightRGB(L)
 
 		If L.Kind = l.KIND_DIRECTIONAL Then
 			Dim wi As Vec3 = Math3D.Normalize(Math3D.Mul(L.Direction, -1))
@@ -1464,10 +1474,11 @@ End Sub
 Private Sub PT_DirectLight(p As Vec3, n As Vec3, base As Vec3, seed As Int, scene As cScene) As Vec3
 	Dim sum As Vec3
 	sum = Math3D.V3(0, 0, 0)
-	Dim i As Int
-	For i = 0 To scene.Lights.Size - 1
-		Dim L As cLight = scene.Lights.Get(i)
-		Dim E As Vec3 = LightRGB(L)
+        Dim i As Int
+        For i = 0 To scene.Lights.Size - 1
+                Dim L As cLight = scene.Lights.Get(i)
+                If L.Enabled = False Then Continue
+                Dim E As Vec3 = LightRGB(L)
 
 		If L.Kind = l.KIND_DIRECTIONAL Then
 			Dim wi As Vec3 = Math3D.Normalize(Math3D.Mul(L.Direction, -1))


### PR DESCRIPTION
## Summary
- add camera and light entries to the objects list popover and adjust handlers for the new entry types
- extend the model bar component to support disabling the visibility toggle and setting its state without raising events
- add an enabled flag to lights and ensure render passes ignore disabled lights
